### PR TITLE
fix(scopename): align scope name to common lower case

### DIFF
--- a/grammars/kotlin.cson
+++ b/grammars/kotlin.cson
@@ -1,6 +1,6 @@
 {
   name: "Kotlin"
-  scopeName: "source.Kotlin"
+  scopeName: "source.kotlin"
   fileTypes: [
     "kt"
     "kts"


### PR DESCRIPTION
I stumbled over this issue on trying to enable Kotlin language support in the atom-language-asciidoc plugin. https://github.com/asciidoctor/atom-language-asciidoc/issues/163

For reasons I do  not fully grasp the scopename needs to be lower case to be able to use

``````
 ```kotlin
    fun kotlinCode(): Unit
 ```
``````

This won't work currently and requires you to type "Kotlin" instead.

It seems to be common practice to name all grammas in lower case:
## Check source language support
- Open the _Developer Tools_: Ctrl+Shift+I on Linux and Windows, Cmd+Alt+i on Mac OS X.
- Run the query
  `Object.keys(atom.grammars.grammarsByScopeName).sort().join('\n')`
  in the _Console_.
## Example language query (you'll spot the runaway ;-) )

```
source.asciidoc
source.asciidoc.properties
source.c
source.cake
source.clojure
source.coffee
source.cpp
source.cs
source.css
source.css.less
source.css.scss
source.csx
source.gfm
source.git-config
source.go
source.gotemplate
source.java
source.java-properties
source.js
source.js.rails source.js.jquery
source.js.regexp
source.js.regexp.replacement
source.json
source.Kotlin
source.litcoffee
source.makefile
source.nant-build
source.objc
source.objcpp
source.perl
source.perl6
source.plist
source.python
source.regexp.python
source.ruby
source.ruby.rails
source.ruby.rails.rjs
source.sass
source.shell
source.sql
source.sql.mustache
source.sql.ruby
source.strings
source.toml
source.yaml
text.git-commit
text.git-rebase
text.html.basic
text.html.erb
text.html.gohtml
text.html.jsp
text.html.mustache
text.html.php
text.html.ruby
text.hyperlink
text.junit-test-report
text.plain
text.plain.null-grammar
text.python.console
text.python.traceback
text.shell-session
text.todo
text.xml
text.xml.plist
text.xml.xsl
```
