### PR TITLE
Fix automatic builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "language-kotlin",
-  "main": "./lib/language-kotlin",
   "version": "0.5.0",
   "description": "Adds syntax highlighting to Kotlin files in Atom",
   "repository": "https://github.com/alexmt/atom-kotlin-language",


### PR DESCRIPTION
If this is included in the atom build chain, it will fail (the actual path doesn't exist).
The main tag is not necessary anyways, so it can be removed
