### PR TITLE
Update kotlin.cson to support nested comments

### DIFF
--- a/grammars/kotlin.cson
+++ b/grammars/kotlin.cson
@@ -62,6 +62,7 @@
 
           end: "\\*/"
           name: "comment.block.kotlin"
+          patterns: [include: "#comments"]
         }
         {
           captures:


### PR DESCRIPTION
Fix for syntax highlighting not supporting nested comments - #12 

Based the fix on this thread - http://textmate.1073791.n5.nabble.com/TextMate-grammars-and-nested-multiline-comments-td28743.html

