### PR TITLE
handle reference equality properly

### DIFF
--- a/grammars/kotlin.cson
+++ b/grammars/kotlin.cson
@@ -600,7 +600,7 @@
           name: "keyword.operator.kotlin"
         }
         {
-          match: "(==|!=|===|!==|<=|>=|<|>)"
+          match: "(===|==|!==|!=|<=|>=|<|>)"
           name: "keyword.operator.comparison.kotlin"
         }
         {


### PR DESCRIPTION
Reference equality operators were not being scoped properly, which was visible when using a font with code ligatures such as Fira Code.